### PR TITLE
use platform for hostname check instead of os

### DIFF
--- a/check-system.py
+++ b/check-system.py
@@ -1,5 +1,5 @@
 import platform
-import os
 
+print("Retrieving System information...\n")
 print(f"System: {platform.system()}")
-print(f"Hostname: {os.uname()[1]}")
+print(f"Hostname: {platform.node()}")


### PR DESCRIPTION
Improved the code by using the platform module for hostname checks. This made the os module an unused import and reduced the quantum of external code.